### PR TITLE
Arcade Maze Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "battlesnake-game-types"
 version = "0.14.1"
-source = "git+https://github.com/coreyja/battlesnake-game-types.git?rev=c15fe62#c15fe62f0a4ebb499024ed786218ecfcb1f91439"
+source = "git+https://github.com/coreyja/battlesnake-game-types.git?rev=c1151b5#c1151b5e7be04235640a620a38ff8ddfdd65b9d3"
 dependencies = [
  "fxhash",
  "itertools 0.10.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "battlesnake-game-types"
 version = "0.14.1"
-source = "git+https://github.com/coreyja/battlesnake-game-types.git?rev=82aa99e#82aa99e25f71fbcda46040bc8c3f454b434a7fc3"
+source = "git+https://github.com/coreyja/battlesnake-game-types.git?rev=c15fe62#c15fe62f0a4ebb499024ed786218ecfcb1f91439"
 dependencies = [
  "fxhash",
  "itertools 0.10.3",

--- a/battlesnake-minimax/Cargo.toml
+++ b/battlesnake-minimax/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # battlesnake-game-types = "0.11.1"
 # battlesnake-game-types = { git = "https://github.com/penelopezone/battlesnake-game-types.git", branch = "main" }
-battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "82aa99e" }
+battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c15fe62" }
 # battlesnake-game-types = { path = "../../battlesnake-game-types" }
 
 itertools = "0.10.0"

--- a/battlesnake-minimax/Cargo.toml
+++ b/battlesnake-minimax/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # battlesnake-game-types = "0.11.1"
 # battlesnake-game-types = { git = "https://github.com/penelopezone/battlesnake-game-types.git", branch = "main" }
-battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c15fe62" }
+battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c1151b5" }
 # battlesnake-game-types = { path = "../../battlesnake-game-types" }
 
 itertools = "0.10.0"

--- a/battlesnake-rs/Cargo.toml
+++ b/battlesnake-rs/Cargo.toml
@@ -16,7 +16,7 @@ debug_print = "1.0.0"
 tracing = "0.1.26"
 # battlesnake-game-types = "0.11.1"
 # battlesnake-game-types = { git = "https://github.com/penelopezone/battlesnake-game-types.git", branch = "main" }
-battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "82aa99e" }
+battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c15fe62" }
 # battlesnake-game-types = { path = "../../battlesnake-game-types" }
 
 rustc-hash = "1.1.0"

--- a/battlesnake-rs/Cargo.toml
+++ b/battlesnake-rs/Cargo.toml
@@ -16,7 +16,7 @@ debug_print = "1.0.0"
 tracing = "0.1.26"
 # battlesnake-game-types = "0.11.1"
 # battlesnake-game-types = { git = "https://github.com/penelopezone/battlesnake-game-types.git", branch = "main" }
-battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c15fe62" }
+battlesnake-game-types = { git = "https://github.com/coreyja/battlesnake-game-types.git", rev = "c1151b5" }
 # battlesnake-game-types = { path = "../../battlesnake-game-types" }
 
 rustc-hash = "1.1.0"

--- a/battlesnake-rs/src/a_prime.rs
+++ b/battlesnake-rs/src/a_prime.rs
@@ -1,3 +1,4 @@
+use battlesnake_game_types::compact_representation::dimensions::Dimensions;
 use battlesnake_game_types::compact_representation::{
     CellNum, StandardCellBoard, StandardCellBoard4Snakes11x11, WrappedCellBoard,
 };
@@ -121,8 +122,8 @@ struct Node<T> {
     coordinate: T,
 }
 
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> APrimeCalculable
-    for StandardCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize> APrimeCalculable
+    for StandardCellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
 {
     fn a_prime_inner(
         &self,
@@ -191,9 +192,10 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> APrimeCalcula
 
 impl<
         T: battlesnake_game_types::compact_representation::CellNum,
+        D: Dimensions,
         const BOARD_SIZE: usize,
         const MAX_SNAKES: usize,
-    > APrimeCalculable for WrappedCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+    > APrimeCalculable for WrappedCellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
 {
     fn a_prime_inner(
         &self,
@@ -291,9 +293,10 @@ pub trait HueristicAble: PositionGettableGame {
 
 impl<
         T: battlesnake_game_types::compact_representation::CellNum,
+        D: Dimensions,
         const BOARD_SIZE: usize,
         const MAX_SNAKES: usize,
-    > HueristicAble for StandardCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+    > HueristicAble for StandardCellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
 {
     fn hueristic(
         start: &Self::NativePositionType,
@@ -320,9 +323,10 @@ impl<
 
 impl<
         T: battlesnake_game_types::compact_representation::CellNum,
+        D: Dimensions,
         const BOARD_SIZE: usize,
         const MAX_SNAKES: usize,
-    > HueristicAble for WrappedCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+    > HueristicAble for WrappedCellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
 {
     fn hueristic(
         start: &Self::NativePositionType,

--- a/battlesnake-rs/src/devious_devin_eval.rs
+++ b/battlesnake-rs/src/devious_devin_eval.rs
@@ -4,8 +4,6 @@ use battlesnake_minimax::EvalMinimaxSnake;
 
 use battlesnake_game_types::types::*;
 
-use battlesnake_game_types::compact_representation::StandardCellBoard4Snakes11x11;
-
 pub struct Factory;
 
 #[derive(Serialize, PartialEq, PartialOrd, Ord, Eq, Debug, Copy, Clone)]
@@ -94,17 +92,36 @@ impl Factory {
         Self
     }
 
-    pub fn create(
-        &self,
-        game: Game,
-    ) -> EvalMinimaxSnake<StandardCellBoard4Snakes11x11, ScoreEndState, 4> {
+    pub fn create(&self, game: Game) -> BoxedSnake {
         let game_info = game.game.clone();
         let turn = game.turn;
-        let id_map = build_snake_id_map(&game);
+        let name = "devious-devin";
 
-        let game = StandardCellBoard4Snakes11x11::convert_from_game(game, &id_map).unwrap();
-
-        EvalMinimaxSnake::new(game, game_info, turn, &score, "devious-devin")
+        if game_info.ruleset.name == "wrapped" {
+            match battlesnake_game_types::compact_representation::wrapped::ToBestCellBoard::to_best_cell_board(game).unwrap() {
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Tiny(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::SmallExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Standard(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::MediumExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::LargestU8(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::LargeExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::ArcadeMaze(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Large(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Silly(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+            }
+        } else {
+            match battlesnake_game_types::compact_representation::standard::ToBestCellBoard::to_best_cell_board(game).unwrap() {
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Tiny(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::SmallExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Standard(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::MediumExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::LargestU8(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::LargeExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::ArcadeMaze(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Large(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Silly(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+            }
+        }
     }
 }
 
@@ -120,9 +137,7 @@ impl BattlesnakeFactory for Factory {
     }
 
     fn from_wire_game(&self, game: Game) -> BoxedSnake {
-        let snake = self.create(game);
-
-        Box::new(snake)
+        self.create(game)
     }
 
     fn about(&self) -> AboutMe {

--- a/battlesnake-rs/src/flood_fill/jump_flooding.rs
+++ b/battlesnake-rs/src/flood_fill/jump_flooding.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use battlesnake_game_types::{
-    compact_representation::{CellNum, StandardCellBoard4Snakes11x11, WrappedCellBoard},
+    compact_representation::{
+        dimensions::Dimensions, CellNum, StandardCellBoard4Snakes11x11, WrappedCellBoard,
+    },
     types::{HeadGettableGame, PositionGettableGame, SnakeIDGettableGame},
     wire_representation::Position,
 };
@@ -23,8 +25,8 @@ where
     cells: [Option<T::SnakeIDType>; 11 * 11],
 }
 
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> JumpFlooding
-    for WrappedCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+impl<T: CellNum, D: Dimensions, const BOARD_SIZE: usize, const MAX_SNAKES: usize> JumpFlooding
+    for WrappedCellBoard<T, D, BOARD_SIZE, MAX_SNAKES>
 {
     fn squares_per_snake(&self) -> HashMap<Self::SnakeIDType, usize> {
         let mut grid: Grid<StandardCellBoard4Snakes11x11> = Grid {

--- a/battlesnake-rs/src/flood_fill/spread_from_head.rs
+++ b/battlesnake-rs/src/flood_fill/spread_from_head.rs
@@ -5,24 +5,24 @@ use battlesnake_game_types::compact_representation::*;
 use battlesnake_game_types::types::{
     HazardQueryableGame, HeadGettableGame, LengthGettableGame, NeighborDeterminableGame,
     PositionGettableGame, SizeDeterminableGame, SnakeBodyGettableGame, SnakeIDGettableGame,
+    SnakeId,
 };
 
 use battlesnake_game_types::compact_representation::CellNum;
 use tinyvec::TinyVec;
 
-pub struct Grid<T>
+pub struct Grid<BoardType>
 where
-    T: SnakeIDGettableGame + ?Sized,
-    T::SnakeIDType: Copy,
+    BoardType: SnakeIDGettableGame + ?Sized,
+    BoardType::SnakeIDType: Copy,
 {
-    cells: Vec<Option<T::SnakeIDType>>,
+    cells: Vec<Option<BoardType::SnakeIDType>>,
 }
 
-pub trait SpreadFromHead: SnakeIDGettableGame
-where
-    Self::SnakeIDType: Copy,
-{
-    fn calculate(&self, number_of_cycles: usize) -> Grid<Self>;
+pub trait SpreadFromHead<CellType> {
+    type GridType;
+
+    fn calculate(&self, number_of_cycles: usize) -> Self::GridType;
     fn squares_per_snake(&self, number_of_cycles: usize) -> [u8; 4];
     fn squares_per_snake_with_hazard_cost(
         &self,
@@ -31,27 +31,38 @@ where
     ) -> [u16; 4];
 }
 
-struct CellWrapper<T: CellNum>(CellIndex<T>);
+struct CellWrapper<CellType: CellNum>(CellIndex<CellType>);
 
-impl<T: CellNum> Default for CellWrapper<T> {
+impl<CellType: CellNum> Default for CellWrapper<CellType> {
     fn default() -> Self {
         CellWrapper(CellIndex::from_usize(0))
     }
 }
 
-impl<T: CellNum> Deref for CellWrapper<T> {
-    type Target = CellIndex<T>;
+impl<CellType: CellNum> Deref for CellWrapper<CellType> {
+    type Target = CellIndex<CellType>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SpreadFromHead
-    for StandardCellBoard<T, BOARD_SIZE, MAX_SNAKES>
+impl<BoardType, CellType> SpreadFromHead<CellType> for BoardType
+where
+    BoardType: SnakeIDGettableGame<SnakeIDType = SnakeId>
+        + PositionGettableGame<NativePositionType = CellIndex<CellType>>
+        + SizeDeterminableGame
+        + HazardQueryableGame
+        + LengthGettableGame
+        + NeighborDeterminableGame
+        + HeadGettableGame
+        + SnakeBodyGettableGame,
+    CellType: CellNum,
 {
-    fn calculate(&self, number_of_cycles: usize) -> Grid<Self> {
-        let mut grid: Grid<Self> = Grid {
+    type GridType = Grid<BoardType>;
+
+    fn calculate(&self, number_of_cycles: usize) -> Self::GridType {
+        let mut grid: Grid<BoardType> = Grid {
             cells: vec![None; (self.get_height() * self.get_width()) as usize],
         };
 
@@ -62,7 +73,7 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SpreadFromHea
             sids
         };
 
-        let mut todos: TinyVec<[CellWrapper<T>; 16]> = TinyVec::new();
+        let mut todos: TinyVec<[CellWrapper<CellType>; 16]> = TinyVec::new();
         let mut todos_per_snake: [u8; 4] = [0; 4];
 
         for sid in &sorted_snake_ids {
@@ -135,9 +146,9 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SpreadFromHea
             .enumerate()
             .filter_map(|x| x.1.map(|sid| (x.0, sid)))
             .map(|(i, sid)| {
-                let value = if self
-                    .is_hazard(&<Self as PositionGettableGame>::NativePositionType::from_usize(i))
-                {
+                let value = if self.is_hazard(
+                    &<BoardType as PositionGettableGame>::NativePositionType::from_usize(i),
+                ) {
                     1
                 } else {
                     non_hazard_bonus + 1
@@ -152,109 +163,5 @@ impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SpreadFromHea
         }
 
         total_values
-    }
-}
-
-impl<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usize> SpreadFromHead
-    for WrappedCellBoard<T, BOARD_SIZE, MAX_SNAKES>
-{
-    fn squares_per_snake(&self, number_of_cycles: usize) -> [u8; 4] {
-        let result = self.calculate(number_of_cycles);
-        let cell_sids = result.cells.iter().filter_map(|x| *x);
-
-        let mut total_values = [0; 4];
-
-        for sid in cell_sids {
-            total_values[sid.as_usize()] += 1;
-        }
-
-        total_values
-    }
-
-    fn squares_per_snake_with_hazard_cost(
-        &self,
-        number_of_cycles: usize,
-        non_hazard_bonus: u16,
-    ) -> [u16; 4] {
-        let grid = self.calculate(number_of_cycles);
-
-        let sid_and_values = grid
-            .cells
-            .iter()
-            .enumerate()
-            .filter_map(|x| x.1.map(|sid| (x.0, sid)))
-            .map(|(i, sid)| {
-                let value = if self
-                    .is_hazard(&<Self as PositionGettableGame>::NativePositionType::from_usize(i))
-                {
-                    1
-                } else {
-                    non_hazard_bonus + 1
-                };
-                (sid, value)
-            });
-
-        let mut total_values = [0; 4];
-
-        for (sid, value) in sid_and_values {
-            total_values[sid.as_usize()] += value;
-        }
-
-        total_values
-    }
-
-    fn calculate(&self, number_of_cycles: usize) -> Grid<Self> {
-        let mut grid: Grid<Self> = Grid {
-            cells: vec![None; (self.get_height() * self.get_width()) as usize],
-        };
-
-        let sorted_snake_ids = {
-            let mut sids = self.get_snake_ids();
-            sids.sort_unstable_by_key(|sid| Reverse(self.get_length(sid)));
-
-            sids
-        };
-
-        let mut todos: TinyVec<[CellWrapper<T>; 16]> = TinyVec::new();
-        let mut todos_per_snake: [u8; 4] = [0; 4];
-
-        for sid in &sorted_snake_ids {
-            for pos in self.get_snake_body_iter(sid) {
-                grid.cells[pos.as_usize()] = Some(*sid);
-            }
-        }
-
-        for sid in &sorted_snake_ids {
-            let head = self.get_head_as_native_position(sid);
-            todos.push(CellWrapper(head));
-            todos_per_snake[sid.as_usize()] += 1;
-        }
-
-        for _ in 0..number_of_cycles {
-            let mut new_todos = TinyVec::new();
-            let mut new_todos_per_snake = [0; 4];
-
-            let mut todos_iter = todos.into_iter();
-
-            for sid in &sorted_snake_ids {
-                for _ in 0..todos_per_snake[sid.as_usize()] {
-                    // Mark Neighbors
-                    let pos = todos_iter.next().unwrap();
-
-                    for neighbor in self.neighbors(&pos) {
-                        if grid.cells[neighbor.as_usize()].is_none() {
-                            grid.cells[neighbor.as_usize()] = Some(*sid);
-                            new_todos.push(CellWrapper(neighbor));
-                            new_todos_per_snake[sid.as_usize()] += 1;
-                        }
-                    }
-                }
-            }
-
-            todos = new_todos;
-            todos_per_snake = new_todos_per_snake;
-        }
-
-        grid
     }
 }

--- a/battlesnake-rs/src/hovering_hobbs.rs
+++ b/battlesnake-rs/src/hovering_hobbs.rs
@@ -2,9 +2,7 @@ use crate::a_prime::APrimeCalculable;
 use crate::flood_fill::spread_from_head::SpreadFromHead;
 use crate::*;
 
-use battlesnake_game_types::compact_representation::{
-    StandardCellBoard4Snakes11x11, WrappedCellBoard4Snakes11x11,
-};
+use battlesnake_game_types::compact_representation::{StandardCellBoard, WrappedCellBoard};
 use battlesnake_game_types::types::*;
 use battlesnake_minimax::EvalMinimaxSnake;
 use decorum::N64;
@@ -64,13 +62,15 @@ impl BattlesnakeFactory for Factory {
         let name = "hovering-hobbs";
 
         if game_info.ruleset.name == "wrapped" {
-            let game = WrappedCellBoard4Snakes11x11::convert_from_game(game, &id_map).unwrap();
+            let game =
+                WrappedCellBoard::<u16, { 19 * 21 }, 4>::convert_from_game(game, &id_map).unwrap();
 
             let snake = EvalMinimaxSnake::new(game, game_info, turn, &score, name);
 
             Box::new(snake)
         } else {
-            let game = StandardCellBoard4Snakes11x11::convert_from_game(game, &id_map).unwrap();
+            let game =
+                StandardCellBoard::<u16, { 19 * 21 }, 4>::convert_from_game(game, &id_map).unwrap();
 
             let snake = EvalMinimaxSnake::new(game, game_info, turn, &score, name);
 

--- a/battlesnake-rs/src/hovering_hobbs.rs
+++ b/battlesnake-rs/src/hovering_hobbs.rs
@@ -2,7 +2,6 @@ use crate::a_prime::APrimeCalculable;
 use crate::flood_fill::spread_from_head::SpreadFromHead;
 use crate::*;
 
-use battlesnake_game_types::compact_representation::{StandardCellBoard, WrappedCellBoard};
 use battlesnake_game_types::types::*;
 use battlesnake_minimax::EvalMinimaxSnake;
 use decorum::N64;
@@ -56,24 +55,33 @@ impl BattlesnakeFactory for Factory {
     fn from_wire_game(&self, game: Game) -> BoxedSnake {
         let game_info = game.game.clone();
         let turn = game.turn;
-        let id_map = build_snake_id_map(&game);
 
         let name = "hovering-hobbs";
 
         if game_info.ruleset.name == "wrapped" {
-            let game =
-                WrappedCellBoard::<u16, { 19 * 21 }, 4>::convert_from_game(game, &id_map).unwrap();
-
-            let snake = EvalMinimaxSnake::new(game, game_info, turn, &score, name);
-
-            Box::new(snake)
+            match battlesnake_game_types::compact_representation::wrapped::ToBestCellBoard::to_best_cell_board(game).unwrap() {
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Tiny(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::SmallExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Standard(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::MediumExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::LargestU8(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::LargeExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::ArcadeMaze(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Large(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::wrapped::BestCellBoard::Silly(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+            }
         } else {
-            let game =
-                StandardCellBoard::<u16, { 19 * 21 }, 4>::convert_from_game(game, &id_map).unwrap();
-
-            let snake = EvalMinimaxSnake::new(game, game_info, turn, &score, name);
-
-            Box::new(snake)
+            match battlesnake_game_types::compact_representation::standard::ToBestCellBoard::to_best_cell_board(game).unwrap() {
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Tiny(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::SmallExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Standard(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::MediumExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::LargestU8(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::LargeExact(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::ArcadeMaze(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Large(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+                battlesnake_game_types::compact_representation::standard::BestCellBoard::Silly(game) => Box::new(EvalMinimaxSnake::new(*game, game_info, turn, &score, name)),
+            }
         }
     }
 

--- a/battlesnake-rs/src/hovering_hobbs.rs
+++ b/battlesnake-rs/src/hovering_hobbs.rs
@@ -13,12 +13,11 @@ pub enum Score {
     FloodFill(N64),
 }
 
-pub fn score<T>(node: &T) -> Score
+pub fn score<BoardType, CellType>(node: &BoardType) -> Score
 where
-    T::SnakeIDType: Copy,
-    T: SnakeIDGettableGame<SnakeIDType = SnakeId>
+    BoardType: SnakeIDGettableGame<SnakeIDType = SnakeId>
         + YouDeterminableGame
-        + SpreadFromHead
+        + SpreadFromHead<CellType>
         + APrimeCalculable
         + HeadGettableGame
         + HazardQueryableGame

--- a/battlesnake-rs/src/mcts_snake.rs
+++ b/battlesnake-rs/src/mcts_snake.rs
@@ -93,7 +93,7 @@ impl<
 
         let mut total_number_of_iterations = 0;
 
-        while while_condition(&root_node, total_number_of_iterations) {
+        while while_condition(root_node, total_number_of_iterations) {
             total_number_of_iterations += 1;
 
             let mut next_leaf_node = root_node.next_leaf_node(total_number_of_iterations);


### PR DESCRIPTION
This works by using a vec instead of a backing array as its cell
Storage.

I need to check the benches probably but this shouldn't be a huge
difference I don't think cause this Vec is only created once and uses
the vec macro knowing the total size upfront so should be able to
reserve the whole block at once

Also hardcode hobbs to arcade maze size as a first step to getting a
version that can run multiple sizes better.